### PR TITLE
Refactor/router

### DIFF
--- a/cypress/fixtures/mockSingleMovie.json
+++ b/cypress/fixtures/mockSingleMovie.json
@@ -1,0 +1,18 @@
+{
+  "movie": {
+    "id": 627290,
+    "title": "Antebellum",
+    "poster_path": "https://image.tmdb.org/t/p/original//irkse1FMm9dWemwlxKJ7RINT9Iy.jpg",
+    "backdrop_path": "https://image.tmdb.org/t/p/original//pGqBDYycGWsMYc57sYv5M9GAQoW.jpg",
+    "release_date": "2020-09-02",
+    "overview": "Successful author Veronica finds herself trapped in a horrifying reality and must uncover the mind-bending mystery before it's too late.",
+    "genres": [
+      "Horror"
+    ],
+    "budget": "$12,000,000",
+    "revenue": 0,
+    "runtime": 105,
+    "tagline": "If it chooses you, nothing can save you.",
+    "average_rating": 6.571428571428571
+  }
+}

--- a/cypress/integration/movieDetail_spec.js
+++ b/cypress/integration/movieDetail_spec.js
@@ -1,0 +1,50 @@
+describe('Movie Page rendering', () => {
+  beforeEach(() => {
+    cy.fixture('mockSingleMovie').then((movie) => {
+      cy.intercept('https://rancid-tomatillos.herokuapp.com/api/v2/movies/627290', movie)
+    })
+    cy.visit('http://localhost:3000/627290');
+  });
+
+  describe('Should be able to render movie page', () => {
+    it('should contain a header', () => {
+      cy.get('header').contains('Rancid Tomatillos')
+      })
+    
+    it('should have a movie title', ()=> {
+      cy.get('h2').contains('Antebellum')
+    })
+
+    it('should have a tagline', ()=> {
+      cy.get('.tagline').contains('If it chooses you, nothing can save you.')
+    })
+
+    it('should have genres', () => {
+      cy.get('.genres').contains('Horror')
+    })
+
+    it('should a release date', () => {
+      cy.get('.release').contains('2020-09-02')
+    })
+
+    it('should have an overview', () => {
+      cy.get('.overview').contains('Successful author Veronica finds herself trapped in a horrifying reality and must uncover the mind-bending mystery before it\'s too late.')
+    })
+
+    it('should have a rating rounded to 1 decimal', () => {
+      cy.get('.rating').contains(6.6)
+    })
+
+    it('should show a runtime', () => {
+      cy.get('.runtime').contains(105)
+    })
+
+    it('should show a budget', () => {
+      cy.get('.budget').contains('$12,000,000')
+    })
+
+    it('should have a movie image backdrop', () => {
+      cy.get('.backdrop').should('be.visible')
+    })
+  })
+})

--- a/cypress/integration/movieDetail_spec.js
+++ b/cypress/integration/movieDetail_spec.js
@@ -48,3 +48,25 @@ describe('Movie Page rendering', () => {
     })
   })
 })
+
+describe('As a user, i should be able to return to the home page from the movie page', () => {
+  beforeEach(() => {
+    cy.fixture('mockMovies.json').then((movies) => {
+      cy.intercept('https://rancid-tomatillos.herokuapp.com/api/v2/movies', movies)
+    })
+  })  
+  
+  it('should load home page from header click', () => {
+    cy
+      .get('header').click()
+      .url().should('eq', 'http://localhost:3000/')
+  })
+
+  it('should go back to the last page when back button is clicked', () => {
+    
+    cy
+      .go('back')
+      .url().should('eq', 'http://localhost:3000/627290')
+  })
+})
+

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -3,8 +3,9 @@ import React, { Component } from 'react';
 import Header from '../Header/Header';
 import MoviesContainer from '../MoviesContainer/MoviesContainer';
 import MovieDetailer from '../MovieDetailer/MovieDetailer';
+import Error404 from '../Error404/Error404';
 import { allMovies, singleMovie, singleMoviesVideos } from '../../apiCalls';
-import { Route } from 'react-router-dom';
+import { Route, Switch, Redirect } from 'react-router-dom';
 
 class App extends Component {
   constructor() {
@@ -47,9 +48,13 @@ class App extends Component {
     return (
       <main>
         <Header  reload={this.reload}/> 
-        <Route exact path='/' render={() => <MoviesContainer movies={this.state.movies} findMovie={this.findMovie} />} />
-        <Route exact path='/:id' render={({ match }) => {
-        return <MovieDetailer movie={this.state.movie} hanldeSingleMovie={this.hanldeSingleMovie} location={match.params.id} />} }/>
+        <Switch>
+          <Route exact path='/' render={() => <MoviesContainer movies={this.state.movies} findMovie={this.findMovie} />} />
+          <Route exact path='/:id' render={({ match }) => {
+          return <MovieDetailer movie={this.state.movie} hanldeSingleMovie={this.hanldeSingleMovie} location={match.params.id} />} }/>
+          {/* <Route path='*' exact={true} component={Error404}/> */}
+          {/* <Redirect to='/'/> */}
+        </Switch>
       </main>
     );
   }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -21,6 +21,7 @@ class App extends Component {
     allMovies()
       .then(data => this.setState({ movies: data.movies}))
       .catch(err => console.log(err, ' :err from app.js'))
+
     }
     
   findMovie = (id) => {
@@ -47,7 +48,8 @@ class App extends Component {
       <main>
         <Header  reload={this.reload}/> 
         <Route exact path='/' render={() => <MoviesContainer movies={this.state.movies} findMovie={this.findMovie} />} />
-        <Route exact path='/:id' render={() => <MovieDetailer movie={this.state.movie} hanldeSingleMovie={this.hanldeSingleMovie} />} />
+        <Route exact path='/:id' render={({ match }) => {
+        return <MovieDetailer movie={this.state.movie} hanldeSingleMovie={this.hanldeSingleMovie} location={match.params.id} />} }/>
       </main>
     );
   }

--- a/src/components/Error404/Error404.js
+++ b/src/components/Error404/Error404.js
@@ -1,0 +1,11 @@
+import './Error404.css';
+import {Link} from 'react-router-dom';
+
+const Error404 = () => {
+
+  return (
+      <h2>Nope. Nothing here</h2>
+  )
+}
+
+export default Error404;

--- a/src/components/MovieDetailer/MovieDetailer.js
+++ b/src/components/MovieDetailer/MovieDetailer.js
@@ -1,9 +1,7 @@
 import './MovieDetailer.css';
 import { useEffect } from 'react';
-import { useLocation } from 'react-router';
 
-const MovieDetailer = ({ movie, hanldeSingleMovie }) => {
-  const location = useLocation().pathname.slice(1)
+const MovieDetailer = ({ movie, hanldeSingleMovie, location }) => {
 
   useEffect(() => {
     hanldeSingleMovie(location)


### PR DESCRIPTION
### Description
Attempted to refactor using Router to get rid of the UseEffect method in MovieDetailer, but were unsuccessful. Did manage to refactor to get URL endpoint from match.params.id. Added an Error component but ran into a problem using Switch to display it. It currently does not display, even if an endpoint is invalid.

Added Cypress tests for Movie Details page

#### Type of change
- [ ] Bug fix
- [ ] New feature
- [x] New feature that breaks previous code
- [x] Refactor

#### How Has This Been Tested?
- [x] dev tools
- [x] run local:8080
- [x] console.log()

#### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

#### Additional Comments:
